### PR TITLE
Remove invalid category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/ForesightMiningSoftwareCorporation/bevy_fsl_box_f
 documentation = "https://docs.rs/bevy_fsl_box_frame"
 readme = "README.md"
 keywords = ["bevy", "gizmo"]
-categories = ["3D", "game-development"]
+categories = ["game-development"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
When running `cargo publish` it tells me that `3D` is not a valid category, I don't know how it worked in the past but it seems like I need to remove it to publish the new version.